### PR TITLE
Delimit words with pre-existing separators

### DIFF
--- a/lib/slug.ex
+++ b/lib/slug.ex
@@ -45,10 +45,11 @@ defmodule Slug do
     separator = get_separator(opts)
     lowercase? = Keyword.get(opts, :lowercase, true)
     truncate_length = get_truncate_length(opts)
-    ignored_codepoints = get_ignored_codepoints(opts)
+    ignored_codepoints = to_charlist(separator) ++ get_ignored_codepoints(opts)
+    regex = "[" <> Regex.escape(separator) <> "\\s]"
 
     string
-    |> String.split(~r{\s}, trim: true)
+    |> String.split(Regex.compile!(regex), trim: true)
     |> Enum.map(&transliterate(&1, ignored_codepoints))
     |> Enum.filter(&(&1 != ""))
     |> join(separator, truncate_length)

--- a/test/slug_test.exs
+++ b/test/slug_test.exs
@@ -32,6 +32,12 @@ defmodule SlugTest do
     assert Slug.slugify("Hello, World!", separator: "%20") == "hello%20world"
   end
 
+  test "ignore separator characters" do
+    assert Slug.slugify("hello-world") == "hello-world"
+    assert Slug.slugify("--Hello--World--") == "hello-world"
+    assert Slug.slugify("__HELLO__WORLD__", separator: ?_) == "hello_world"
+  end
+
   test "ignore certain characters" do
     assert Slug.slugify("你好，世界", ignore: ["好", "界"]) == "ni好shi界"
     assert Slug.slugify("你好，世界", ignore: "好界") == "ni好shi界"


### PR DESCRIPTION
Pre-existing separators should delimit words.

```elixir
iex> Slug.slugify("hello-world")
"hello-world"
```
```elixir
iex> Slug.slugify("--Hello--World--")
"hello-world"
```

Fixes #5.