### PR TITLE
Support for punctuation in the :ignore option

### DIFF
--- a/lib/slug.ex
+++ b/lib/slug.ex
@@ -7,6 +7,8 @@ defmodule Slug do
   replaced by hyphens.
   """
 
+  @punctuation ~c"!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
+
   @doc """
   Returns `string` as a slug or `nil` if it failed.
 
@@ -45,7 +47,13 @@ defmodule Slug do
     lowercase? = Keyword.get(opts, :lowercase, true)
     truncate_length = get_truncate_length(opts)
     ignored_codepoints = to_charlist(separator) ++ get_ignored_codepoints(opts)
-    regex = "[" <> Regex.escape(separator) <> "[:space:][:punct:]]"
+
+    regex_punctuation =
+      @punctuation
+      |> Enum.filter(fn c -> c not in ignored_codepoints end)
+      |> to_string()
+
+    regex = "[" <> Regex.escape(separator) <> Regex.escape(regex_punctuation) <> "[:space:]]"
 
     string
     |> String.graphemes()

--- a/test/slug_test.exs
+++ b/test/slug_test.exs
@@ -43,6 +43,11 @@ defmodule SlugTest do
     assert Slug.slugify("你好，世界", ignore: "好界") == "ni-好-shi-界"
   end
 
+  test "ignore punctuation" do
+    assert Slug.slugify("test,is a.test", ignore: [",", "."]) == "test,is-a.test"
+    assert Slug.slugify("test,is a.test", ignore: ",") == "test,is-a-test"
+  end
+
   test "truncate to nearest separator" do
     assert Slug.slugify("It's a small world", truncate: -1) == nil
     assert Slug.slugify("It's a small world", truncate: 0) == nil


### PR DESCRIPTION
Hi, thanks for a great library. 

I have a use case in which I needed to ignore underscores, but since they are part of `[:punct:]` using `ignore: "_"` didn't work.

In this PR I extracted out the `:punct:` to a list of characters and then filter out the `ignored_codepoints`.  